### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "delegate": "component-delegate",
     "event": "component-event"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/component/events.git"


### PR DESCRIPTION
So it displays without an * in tools like:
https://www.npmjs.com/package/license-checker